### PR TITLE
Refact/signup error message

### DIFF
--- a/everytime/user/serializers.py
+++ b/everytime/user/serializers.py
@@ -30,6 +30,20 @@ class UserCreateSerializer(serializers.Serializer):
         admission_year = data.get('admission_year')
         if (admission_year, admission_year) not in User.YEAR_CHOICES:
             raise serializers.ValidationError('학번을 올바르게 입력하세요.')
+
+        username = data.get('username')
+        email = data.get('email')
+        nickname = data.get('nickname')
+
+        queryset = User.objects.filter(username=username) | User.objects.filter(email=email) | User.objects.filter(nickname=nickname)
+
+        if queryset.filter(username=username).exists():
+            raise serializers.ValidationError('이미 존재하는 아이디입니다.')
+        if queryset.filter(email=email).exists():
+            raise serializers.ValidationError('이미 존재하는 이메일입니다.')
+        if queryset.filter(nickname=nickname).exists():
+            raise serializers.ValidationError('이미 존재하는 닉네임입니다.')
+
         return data
 
     def create(self, validated_data):

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -24,7 +24,7 @@ class UserSignUpView(APIView):
         try:
             user, jwt_token = serializer.save()
         except IntegrityError:
-            return Response(status=status.HTTP_409_CONFLICT, data='이미 존재하는 유저입니다.')
+            return Response(status=status.HTTP_409_CONFLICT, data='DATABASE ERROR : 서버 관리자에게 문의주세요.')
 
         return Response({
             'user' : user.username,


### PR DESCRIPTION
username, email, nickname 중복 시 각 필드별로 에러메세지를 다르게 했습니다.
queryset에 접근하는 횟수롤 최소화시키려 했는데 제대로 반영이 됐는지는 모르겠네요...
그리고 저 3가지 경우 이외에 integrity error가 나는 경우에 서버 관리자에게 문의를 달라는 문구 추가했습니다.