### PR TITLE
Feat/post delete

### DIFF
--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -44,8 +44,9 @@ class PostSerializer(serializers.ModelSerializer):
         user = request.user
 
         tags = []
-        for tag in request.data.getlist('tags'):
-            tags.append(Tag.objects.get(name__iexact=tag))
+        if hasattr(request.data, 'getlist'):
+            for tag in request.data.getlist('tags'):
+                tags.append(Tag.objects.get(name__iexact=tag))
         if len(tags) != 0:
             data['tags']=tags
 
@@ -97,6 +98,8 @@ class PostSerializer(serializers.ModelSerializer):
             for tag in new_tags:
                 if tag not in past_tags:
                     PostTag.objects.create(post=post, tag=tag)
+        else: # new_tags is None
+            post.posttag_set.all().delete()
 
         # 입력된 값들에 한해서 기존 게시글 수정 (e.g. title key가 없으면 제목은 수정 안 함)
         for attr, value in validated_data.items():

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -57,3 +57,15 @@ class PostViewSet(viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(self.get_serializer(post).data, status=status.HTTP_201_CREATED)
+
+    def destroy(self, request, pk=None):
+        post = get_object_or_404(Post, pk=pk)
+        tags = list(post.tags.all()) # 이렇게 하지 않으면 post.delete() 이후에 tags도 비어있게 됨.
+        print('1', tags)
+        post.delete()
+        print('2', tags)
+        for tag in tags:
+            print(tag.name, tag.posttag_set.count())
+            if tag.posttag_set.count() == 0:
+                tag.delete()
+        return Response("%s번 게시글이 삭제되었습니다." % pk, status=status.HTTP_200_OK)


### PR DESCRIPTION
기능 추가
- post delete 기능 구현

refactoring
- update 시에 tag가 사라졌을 때, 해당 태그를 사용하는 게시글의 숫자가 0이면 해당 태그를 삭제하는 기능구현

에러 수정
- post create or update 시에 reqeust에 tags가 없으면 나는 에러 수정

알아낸 점
reqeust.data의 데이터타입은 dict인데, dict의 경우 value가 list 형식이면 getlist(key) 로 불러내야함.
그런데 dict안에 배열로 된 키가 전무할 경우에 getlist라는 함수 자체가 구현되지 않는 것 같음.
따라서 hasattr(reqeust.data, 'getlist') 와 같은 방법으로 해당 메소드가 있는지 꼭 체크해야함!! (아니면 걍 try except 문을 사용해도 될 것 같아)