### PR TITLE
Refact/post image delete

### DIFF
--- a/everytime/post/models.py
+++ b/everytime/post/models.py
@@ -36,6 +36,10 @@ class PostImage(models.Model):
     post = models.ForeignKey('Post', on_delete=models.CASCADE)
     image = models.ImageField(upload_to=postimage_upload_func, null=True, blank=True)
 
+    def delete(self, using=None, keep_parents=False):
+        self.image.delete(save=False)
+        super().delete(using, keep_parents)
+
 
 class Tag(models.Model):
     name = models.CharField(max_length=30, blank=False, primary_key=True)

--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -85,10 +85,10 @@ class PostSerializer(serializers.ModelSerializer):
     def update(self, post, validated_data):
         # 기존 이미지 삭제 후 교체 -> 근데 변경된 이미지만 부분적으로 바꾸거나 추가하는 방법이 있을까?
         image_set = self.context['request'].FILES
-        if image_set is not None:
-            PostImage.objects.filter(post=post).delete()
-            for image_data in image_set.getlist('image'):
-                PostImage.objects.create(post=post, image=image_data)
+        for existing_image in post.postimage_set.all():
+            existing_image.delete()
+        for image_data in image_set.getlist('image'):
+            PostImage.objects.create(post=post, image=image_data)
 
         # 기존 태그에서 사라진 부분은 제거 후 새로 생긴 태그 추가
         new_tags = validated_data.pop('tags') if 'tags' in validated_data else None

--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -39,14 +39,6 @@ class PostSerializer(serializers.ModelSerializer):
         image = obj.postimage_set.all()
         return PostImageSerializer(instance=image, many=True).data
 
-    # board field 의 input과 output에 다른 field를 사용하기 위한 코드임.
-    def to_internal_value(self, data):
-        self.fields['board'] = serializers.PrimaryKeyRelatedField(queryset=Board.objects.all())
-        internal_value = super().to_internal_value(data)
-        self.fields['board'] = serializers.StringRelatedField(read_only=True)
-
-        return internal_value
-
     def validate(self, data):
         print(data)
         request = self.context['request']
@@ -64,6 +56,14 @@ class PostSerializer(serializers.ModelSerializer):
         return data
     
     def create(self, validated_data):
+        request = self.context['request']
+        try:
+            board = request.query_params['board']
+            board = Board.objects.get(id=board)
+            validated_data['board'] = board
+        except:
+            raise serializers.ValidationError("board를 query parameter로 입력해주세요")
+
         # tags 따로 저장하기
         tags = validated_data.pop('tags') if 'tags' in validated_data else None
 

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -69,7 +69,8 @@ class PostViewSet(viewsets.GenericViewSet):
     def destroy(self, request, pk=None):
         post = get_object_or_404(Post, pk=pk)
         tags = list(post.tags.all())  # 이렇게 하지 않으면 post.delete() 이후에 tags도 비어있게 됨.
-
+        for image in post.postimage_set.all():
+            image.delete()
         post.delete()
         delete_tag(tags)
         return Response("%s번 게시글이 삭제되었습니다." % pk, status=status.HTTP_200_OK)

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -69,6 +69,7 @@ class PostViewSet(viewsets.GenericViewSet):
     def destroy(self, request, pk=None):
         post = get_object_or_404(Post, pk=pk)
         tags = list(post.tags.all())  # 이렇게 하지 않으면 post.delete() 이후에 tags도 비어있게 됨.
+
         post.delete()
         delete_tag(tags)
         return Response("%s번 게시글이 삭제되었습니다." % pk, status=status.HTTP_200_OK)

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -34,11 +34,6 @@ class PostViewSet(viewsets.GenericViewSet):
     def create(self, request):
         data = request.data.copy()
 
-        try:
-            data['board'] =request.query_params['board']
-        except:
-            raise exceptions.ValidationError("board를 query parameter로 입력해주세요")
-
         create_tag(data)
 
         serializer = self.get_serializer(data=data)

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -6,6 +6,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from .models import Post, Tag
+from board.models import Board
 from .serializers import PostSerializer
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -31,7 +32,12 @@ class PostViewSet(viewsets.GenericViewSet):
     queryset = Post.objects.all()
 
     def create(self, request):
-        data = request.data
+        data = request.data.copy()
+
+        try:
+            data['board'] =request.query_params['board']
+        except:
+            raise exceptions.ValidationError("board를 query parameter로 입력해주세요")
 
         create_tag(data)
 


### PR DESCRIPTION
# Refactoring 내역
- post를 삭제하거나 update 하면서 기존 이미지가 제거될 때, RDS에서 이미지의 URL만 제거되고 S3에서 실제 이미지는 제거되지 않았던 것을 수정
- post 를 update 할 때 pk를 주기 때문에 굳이 board query parameter가 필요없음. 그리고 retrieve, destroy API와의 통일성의 위해 해당 부분을 수정했음

# 공부한 부분
- 성복이가 이미 settings.py를 잘 구현해놓았기 때문에 S3상에 이미지를 삭제할 때는, `[모델인스턴스].[필드명].delete()` 이렇게 하면 됨
    ex) postimage.image.delete(save=False), save=False 하는 이유는 S3상에 이미지만 삭제하고 인스턴스에는 변화를 주지 않기 위해서 인 것 같음
- PostSerializer에 validate 함수에 queryparam으로부터 board 정보를 받아오는 부분이 구현되어 있었음. 그래서 is_valid()를 사용하는 create와 update API 에서는 queryparam 에 board 정보를 명시해야만 했음. 따라서, create에서만 queryparam를 적용하기 위해서는 board 정보를 받아오는 코드가 ViewSet 의 create 부분이나 Serializer의 create 부분에 구현되어야 함. 근데 ViewSet에 구현하자니 결국 Serializer의 to_internal_value 를 overriding 하는 등 양쪽 다 건드릴 수 밖에 없어서 그냥 Serializer의 create 부분에 구현했음. 작동 원리는 기존과 같고 validate에 있는 코드를 옮긴 것 뿐이니까 이해하기 어렵진 않을 거야