### PR TITLE
Refact CI

### DIFF
--- a/.github/workflows/back_CI.yml
+++ b/.github/workflows/back_CI.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run Tests
       run: |
         cd everytime
-        python manage.py test
+        python manage.py test --no-input
       env:
         SECRET_KEY: ${{ secrets.SECRET_KEY }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
ci에서 종종 test database가 drop 되지 않아서 중간에 에러가 나는 경우가 있는데
이게 실제로 터미널에서 실행해보면, test database가 남아있더라도 이것을 삭제하고 테스트를 계속 할 것인지 yes or no로 입력을 받더라고.
그래서 ci 도중 사용자의 입력을 필요로 하는 부분이 생겼을 때 기본값으로 자동 입력을 하는 코드를 추가함 (위의 경우, yes가 기본값임)