### PR TITLE
Refact/social user create api

### DIFF
--- a/everytime/user/serializers.py
+++ b/everytime/user/serializers.py
@@ -87,7 +87,6 @@ class UserLoginSerializer(serializers.Serializer):
 
 
 class SocialUserCreateSerializer(serializers.Serializer):
-    email = serializers.EmailField(required=True, max_length=255)
     nickname = serializers.CharField(required=True, max_length=30)
     univ = serializers.CharField(required=True, max_length=50)
     admission_year = serializers.ChoiceField(choices=User.YEAR_CHOICES, required=True)
@@ -99,31 +98,25 @@ class SocialUserCreateSerializer(serializers.Serializer):
         if (admission_year, admission_year) not in User.YEAR_CHOICES:
             raise serializers.ValidationError('학번을 올바르게 입력하세요.')
 
-        email = data.get('email')
         nickname = data.get('nickname')
-
-        queryset = User.objects.filter(email=email) | User.objects.filter(nickname=nickname)
-
-        if queryset.filter(email=email).exists():
-            raise serializers.ValidationError('이미 존재하는 이메일입니다.')    # 이미 존재하는 이메일일 때, 소셜 계정 연동을 허용해줄것인가 소셜로그인을 막을것인가?
-        if queryset.filter(nickname=nickname).exists():
+        if User.objects.filter(nickname=nickname).exists():
             raise serializers.ValidationError('이미 존재하는 닉네임입니다.')
 
         return data
 
     def create(self, validated_data):
+        username = validated_data.get('social_id')
+        provider = validated_data.get('provider')
         email = validated_data.get('email')
         nickname = validated_data.get('nickname')
         admission_year = validated_data.get('admission_year')
         univ = validated_data.get('univ')
         profile_picture = validated_data.get('profile_picture')
-        # username, password를 None으로 해줘도 되는가,,
-        user = User.objects.create_user(None, email, None, nickname=nickname, admission_year=admission_year, univ=univ, profile_picture=profile_picture)
-        # SocialAccount.objects.create(social_id=, provider=, user=user)
+
+        # password를 None으로 설정하면 set_password(None)이 쓰이는데,
+        # set_password에 None을 전달하면 set_unusable_password()와 동일
+        user = User.objects.create_user(username, email, password=None, nickname=nickname, admission_year=admission_year, univ=univ, profile_picture=profile_picture)
+        SocialAccount.objects.create(social_id=username, provider=provider, user=user)
         jwt_token = jwt_token_of(user)
         return user, jwt_token
 
-    # ???
-    # 1. 소셜계정으로부터 들고온 정보와 유저가 입력한 정보를 어떻게 둘 다 활용할 수 있는지
-    # 2. 소셜계정의 이메일이 이미 일반 회원가입을 한 이메일일 때, 소셜 계정 연동을 허용해줄것인가 소셜로그인을 막을것인가
-    # 3. 소셜가입을 하는 경우 username, password를 None으로 해주는 것이 맞는가, 맞다면 모델수정이 필요한가

--- a/everytime/user/serializers.py
+++ b/everytime/user/serializers.py
@@ -48,7 +48,12 @@ class UserCreateSerializer(serializers.Serializer):
         if queryset.filter(username=username).exists():
             raise serializers.ValidationError('이미 존재하는 아이디입니다.')
         if queryset.filter(email=email).exists():
-            raise serializers.ValidationError('이미 존재하는 이메일입니다.')
+            user = User.objects.get(email=email)
+            if SocialAccount.objects.filter(user=user).exists():
+                # 해당 이메일을 활용하여 소셜로그인/가입을 먼저 한 경우
+                raise serializers.ValidationError('소셜계정으로 가입된 이메일입니다. 소셜로그인을 활용해주세요.')
+            else:
+                raise serializers.ValidationError('이미 존재하는 이메일입니다.')
         if queryset.filter(nickname=nickname).exists():
             raise serializers.ValidationError('이미 존재하는 닉네임입니다.')
 

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -297,7 +297,7 @@ class SocialUserSignUpView(APIView):
         social_id = data.get('social_id')
         provider = data.get('provider')
         if SocialAccount.objects.filter(social_id=social_id, provider=provider).exists():
-            return JsonResponse({"error": "이미 존재하는 유저입니다."}, status=status.HTTP_400_BAD_REQUEST)
+            return JsonResponse({"error": "이미 존재하는 소셜 계정 유저입니다."}, status=status.HTTP_400_BAD_REQUEST)
 
         # requests.data의 'email'에 대한 전제사항
         # 소셜로그인 callback 함수에서 JsonResponse로 반환된 email이 None이 아니라면, 그 값을 가짐 (사용자가 따로 입력할 수 없도록 프론트단에서 처리)

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -292,23 +292,28 @@ class SocialUserSignUpView(APIView):
     permission_classes = (permissions.AllowAny,)
 
     def post(self, request, *args, **kwargs):
+        # 해당 소셜 계정으로 이미 가입이 되어있는지 체크 - 사실 정상적인 경로를 통해 유입되었다면 이 signup이 아니라 login으로 연결되었을 것
+        data = request.data
+        social_id = data.get('social_id')
+        provider = data.get('provider')
+        if SocialAccount.objects.filter(social_id=social_id, provider=provider).exists():
+            return JsonResponse({"error": "이미 존재하는 유저입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
         # requests.data의 'email'에 대한 전제사항
         # 소셜로그인 callback 함수에서 JsonResponse로 반환된 email이 None이 아니라면, 그 값을 가짐 (사용자가 따로 입력할 수 없도록 프론트단에서 처리)
         # None이었다면 사용자에게 입력을 받은 이메일 값을 가짐
 
         # 이메일 중복 처리 - 소셜계정의 이메일로 이미 일반 회원가입을 한 상태일 때, 소셜 계정을 기존회원정보와 연동
-        data = request.data
         social_email = data.get('email')
         if not social_email:
             return JsonResponse({"email": "이메일을 입력하세요."}, status=status.HTTP_400_BAD_REQUEST)
         if User.objects.filter(email=social_email).exists():
             user = User.objects.get(email=social_email)
-            social_id = data.get('social_id')
-            provider = data.get('provider')
             SocialAccount.objects.create(social_id=social_id, provider=provider, user=user)
             return Response({
                 'notice': '동일한 이메일로 가입한 이력이 존재하여 기존 계정과 소셜 계정을 연동하였습니다. 기존 로그인과 소셜로그인을 모두 활용할 수 있습니다.',
-                'social_user': user.username,
+                'user': user.username,
+                'social_id': social_id,
                 'token': jwt_token_of(user)
             }, status=status.HTTP_201_CREATED)
 
@@ -325,7 +330,7 @@ class SocialUserSignUpView(APIView):
             return Response(status=status.HTTP_409_CONFLICT, data='DATABASE ERROR : 서버 관리자에게 문의주세요.')
 
         return Response({
-            'social_user': user.username,
+            'social_user': user.username,   # social_id 값임
             'token': jwt_token
         }, status=status.HTTP_201_CREATED)
 


### PR DESCRIPTION
## 소셜 가입용 API

Response body로 다음 사항이 필요
- social_id : social login callback에서 JsonResponse로 반환된 값의 social_id 값 그대로 전달 (유저가 입력하지 않음)
- provider : social login callback에서 JsonResponse로 반환된 값의 provider값 그대로 전달 (유저가 입력하지 않음)
- email : social login callback 함수에서 JsonResponse로 반환된 값의 email에 해당하는 값이    
               None이 아니라면 그대로 전달하고, 회원가입 페이지에서 이메일을 입력할 수 없도록 함  
               None이라면 회원가입 페이지에서 이메일을 입력할 수 있도록 하고 그 값을 가짐
- nickname
- admission_year
- univ
- profile_picture(선택 사항)


nickname, admission_year의 validation 이전에 email validation을 먼저 진행함. (기존 계정과의 연동 or 소셜가입 유무를 알기 위해)
따라서 nickname을 기존 계정들의 것과 겹치게 입력하든, admission_year에 허용되지 않는 값을 입력하든,  
이와 상관없이 email이 기존회원의 정보와 겹친다면 소셜계정을 자동으로 연동하고 끝냄.

email이 기존회원정보에 겹치지 않는다면 새로 회원가입을 하는 것이니, 필드의 validation을 진행한 후 회원가입시킴.  
social_id가 User모델의 username으로 사용됨.

<추가할 수 있는 사항>
1. email이 기존회원의 정보와 겹치는 경우, 기존 계정을 소셜계정과 연동할 거냐고 먼저 사용자에게 물어볼 수 있으면 더 좋을 것 같음
2. 소셜회원가입을 먼저 한 후 동일한 이메일로 일반회원 가입을 하려 할 때, 현재는 '소셜계정으로 가입된 이메일입니다. 소셜로그인을 활용해주세요.'이 뜨도록 했는데, 에러로 이어지지 않고 일반회원가입+소셜계정연동을 할 수 있게도 할 수는 있을 거 같음