### PR TITLE
Fix/sociallogin deploy

### DIFF
--- a/.github/workflows/back_CI.yml
+++ b/.github/workflows/back_CI.yml
@@ -51,3 +51,4 @@ jobs:
         EMAIL_HOST_PASSWORD: ${{ secrets.EMAIL_HOST_PASSWORD }}
         SERVER_EMAIL: ${{ secrets.SERVER_EMAIL }}
         REDIRECT_PAGE: ${{ secrets.REDIRECT_PAGE }}
+        BASE_URL: ${{ secrets.BASE_URL }}

--- a/everytime/user/urls.py
+++ b/everytime/user/urls.py
@@ -1,21 +1,21 @@
 from django.urls import path, include
 
 from rest_framework.routers import SimpleRouter
-from .views import UserSignUpView, UserLoginView, google_login, google_callback, VerifyingMailSendView, VerifyingMailAcceptView, SocialUserSignUpView, KaKaoLoginView, kakao_callback
 from . import views
 
 
 app_name='user'
 urlpatterns = [
-    path('signup/', UserSignUpView.as_view(), name='signup'),
-    path('login/', UserLoginView.as_view(), name='login'),
-    path('kakao/login/', KaKaoLoginView.as_view(), name='kakao login'),
-    path('kakao/callback/', kakao_callback, name='kakao callback'),
-    path('google/login/', google_login, name='google_login'),
-    path('google/login/callback/', google_callback,  name='google_callback'),
-    path('verify/send/', VerifyingMailSendView.as_view(), name='email_verify_send'),
-    path('verify/accepted/<str:uidb64>/<str:token>/<str:emailb64>/', VerifyingMailAcceptView.as_view(), name='email_verify_send'),
-    path('social/signup/', SocialUserSignUpView.as_view(), name='social_signup'),
-    path('naver/login/', views.naver_login, name='naver_login'),
+    path('signup/', views.UserSignUpView.as_view(), name='signup'),
+    path('login/', views.UserLoginView.as_view(), name='login'),
+    path('kakao/login/', views.KaKaoLoginView.as_view(), name='kakao login'),
+    path('kakao/callback/', views.kakao_callback, name='kakao callback'),
+    path('google/login/', views.GoogleLoginView.as_view(), name='google_login'),
+    path('google/login/callback/', views.google_callback,  name='google_callback'),
+    path('social/signup/', views.SocialUserSignUpView.as_view(), name='social_signup'),
+    path('naver/login/', views.NaverLoginView.as_view(), name='naver_login'),
     path('naver/login/callback/', views.naver_callback, name='naver_callback'),
+    path('verify/send/', views.VerifyingMailSendView.as_view(), name='email_verify_send'),
+    path('verify/accepted/<str:uidb64>/<str:token>/<str:emailb64>/', views.VerifyingMailAcceptView.as_view(),
+         name='email_verify_accept'),
 ]

--- a/everytime/user/utils.py
+++ b/everytime/user/utils.py
@@ -11,5 +11,5 @@ class EmailVerificationTokenGenerator(PasswordResetTokenGenerator):
 
 email_verification_token = EmailVerificationTokenGenerator()
 
-def message(domain, uidb64, token, emailb64):
-    return f"아래 링크를 클릭하면 학교 인증이 완료됩니다.\n\n학교인증 링크 : http://{domain}/user/verify/accepted/{uidb64}/{token}/{emailb64}/\n\n감사합니다."
+def message(uidb64, token, emailb64):
+    return f"아래 링크를 클릭하면 학교 인증이 완료됩니다.\n\n학교인증 링크 : https://waffle-minkyu.shop/user/verify/accepted/{uidb64}/{token}/{emailb64}/\n\n감사합니다."

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -76,7 +76,7 @@ class UserLoginView(APIView):
 class KaKaoLoginView(APIView):
     permission_classes = (permissions.AllowAny, )
     def get(self, request):
-        REST_API_KEY = '4c3c166a3ec7e5a2da86cb7f358a1a17'
+        REST_API_KEY = getattr(settings, 'SOCIAL_AUTH_KAKAO_SECRET')
         REDIRECT_URI = 'http://localhost:8000/user/kakao/callback/'
 
         API_HOST = f'https://kauth.kakao.com/oauth/authorize?client_id={REST_API_KEY}&redirect_uri={REDIRECT_URI}&response_type=code'
@@ -98,7 +98,10 @@ def kakao_callback(request):
     try:
         code = request.GET.get("code")
         REST_API_KEY = getattr(settings, 'SOCIAL_AUTH_KAKAO_SECRET')
-        REDIRECT_URI = 'http://localhost:8000/user/kakao/callback/'
+        BASE_URL = getattr(settings, 'BASE_URL')
+        if BASE_URL == "http://127.0.0.1:8000/":
+            BASE_URL = 'http://localhost:8000/'
+        REDIRECT_URI = BASE_URL + 'user/kakao/callback/'
         token_response = requests.get(
             f"https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id={REST_API_KEY}&redirect_uri={REDIRECT_URI}&code={code}"
         )
@@ -150,9 +153,6 @@ class SocialLoginException(APIException):
 
       
 
-state = getattr(settings, 'STATE')
-BASE_URL = 'http://127.0.0.1:8000/'
-GOOGLE_CALLBACK_URI = BASE_URL + 'user/google/login/callback/'
 
 
 
@@ -160,6 +160,8 @@ def google_login(request):
     """
     Code Request
     """
+    BASE_URL = getattr(settings, 'BASE_URL')
+    GOOGLE_CALLBACK_URI = BASE_URL + 'user/google/login/callback/'
     scope = "https://www.googleapis.com/auth/userinfo.profile" + \
             " https://www.googleapis.com/auth/userinfo.email"
     client_id = getattr(settings, "SOCIAL_AUTH_GOOGLE_CLIENT_ID")
@@ -167,7 +169,9 @@ def google_login(request):
 
 
 def google_callback(request):
-
+    state = getattr(settings, 'STATE')
+    BASE_URL = getattr(settings, 'BASE_URL')
+    GOOGLE_CALLBACK_URI = BASE_URL + 'user/google/login/callback/'
     client_id = getattr(settings, "SOCIAL_AUTH_GOOGLE_CLIENT_ID")
     client_secret = getattr(settings, "SOCIAL_AUTH_GOOGLE_SECRET")
     code = request.GET.get('code')
@@ -215,13 +219,13 @@ def google_callback(request):
 
       
 # Code chunks below are mostly from https://medium.com/chanjongs-programming-diary/django-rest-framework로-소셜-로그인-api-구현해보기-google-kakao-github-2ccc4d49a781
-BASE_URL = 'http://127.0.0.1:8000/'
-NAVER_CALLBACK_URI = BASE_URL + 'user/naver/login/callback/'
-CLIENT_ID = getattr(settings, 'SOCIAL_AUTH_NAVER_CLIENT_ID')
-CLIENT_SECRET = getattr(settings, 'SOCIAL_AUTH_NAVER_SECRET')
+
 
 
 def naver_login(request):
+    BASE_URL = getattr(settings, 'BASE_URL')
+    NAVER_CALLBACK_URI = BASE_URL + 'user/naver/login/callback/'
+    CLIENT_ID = getattr(settings, 'SOCIAL_AUTH_NAVER_CLIENT_ID')
     if request.user.is_authenticated:
         messages.error(request, '이미 로그인된 유저입니다.')
         return redirect(BASE_URL)
@@ -234,6 +238,8 @@ def naver_login(request):
 
 
 def naver_callback(request):
+    CLIENT_ID = getattr(settings, 'SOCIAL_AUTH_NAVER_CLIENT_ID')
+    CLIENT_SECRET = getattr(settings, 'SOCIAL_AUTH_NAVER_SECRET')
     code = request.GET.get('code')
     state = request.GET.get('state')
     original_state = request.session.get('original_state')

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -77,7 +77,10 @@ class KaKaoLoginView(APIView):
     permission_classes = (permissions.AllowAny, )
     def get(self, request):
         REST_API_KEY = getattr(settings, 'SOCIAL_AUTH_KAKAO_SECRET')
-        REDIRECT_URI = 'http://localhost:8000/user/kakao/callback/'
+        BASE_URL = getattr(settings, 'BASE_URL')
+        if BASE_URL == "http://127.0.0.1:8000/":
+            BASE_URL = 'http://localhost:8000/'
+        REDIRECT_URI = BASE_URL + 'user/kakao/callback/'
 
         API_HOST = f'https://kauth.kakao.com/oauth/authorize?client_id={REST_API_KEY}&redirect_uri={REDIRECT_URI}&response_type=code'
         try:
@@ -156,16 +159,18 @@ class SocialLoginException(APIException):
 
 
 
-def google_login(request):
-    """
-    Code Request
-    """
-    BASE_URL = getattr(settings, 'BASE_URL')
-    GOOGLE_CALLBACK_URI = BASE_URL + 'user/google/login/callback/'
-    scope = "https://www.googleapis.com/auth/userinfo.profile" + \
-            " https://www.googleapis.com/auth/userinfo.email"
-    client_id = getattr(settings, "SOCIAL_AUTH_GOOGLE_CLIENT_ID")
-    return redirect(f"https://accounts.google.com/o/oauth2/v2/auth?client_id={client_id}&response_type=code&redirect_uri={GOOGLE_CALLBACK_URI}&scope={scope}")
+class GoogleLoginView(APIView):
+    permission_classes = (permissions.AllowAny, )
+    def get(self, request):
+        """
+        Code Request
+        """
+        BASE_URL = getattr(settings, 'BASE_URL')
+        GOOGLE_CALLBACK_URI = BASE_URL + 'user/google/login/callback/'
+        scope = "https://www.googleapis.com/auth/userinfo.profile" + \
+                " https://www.googleapis.com/auth/userinfo.email"
+        client_id = getattr(settings, "SOCIAL_AUTH_GOOGLE_CLIENT_ID")
+        return redirect(f"https://accounts.google.com/o/oauth2/v2/auth?client_id={client_id}&response_type=code&redirect_uri={GOOGLE_CALLBACK_URI}&scope={scope}")
 
 
 def google_callback(request):
@@ -222,19 +227,21 @@ def google_callback(request):
 
 
 
-def naver_login(request):
-    BASE_URL = getattr(settings, 'BASE_URL')
-    NAVER_CALLBACK_URI = BASE_URL + 'user/naver/login/callback/'
-    CLIENT_ID = getattr(settings, 'SOCIAL_AUTH_NAVER_CLIENT_ID')
-    if request.user.is_authenticated:
-        messages.error(request, '이미 로그인된 유저입니다.')
-        return redirect(BASE_URL)
-    # Create random state
-    STATE = ''.join((random.choice(string.digits)) for x in range(15))
-    request.session['original_state'] = STATE
-    return redirect(
-        f"https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id={CLIENT_ID}&state={STATE}&redirect_uri={NAVER_CALLBACK_URI}"
-    )
+class NaverLoginView(APIView):
+    permission_classes = (permissions.AllowAny, )
+    def get(self, request):
+        BASE_URL = getattr(settings, 'BASE_URL')
+        NAVER_CALLBACK_URI = BASE_URL + 'user/naver/login/callback/'
+        CLIENT_ID = getattr(settings, 'SOCIAL_AUTH_NAVER_CLIENT_ID')
+        if request.user.is_authenticated:
+            messages.error(request, '이미 로그인된 유저입니다.')
+            return redirect(BASE_URL)
+        # Create random state
+        STATE = ''.join((random.choice(string.digits)) for x in range(15))
+        request.session['original_state'] = STATE
+        return redirect(
+            f"https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id={CLIENT_ID}&state={STATE}&redirect_uri={NAVER_CALLBACK_URI}"
+        )
 
 
 def naver_callback(request):

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -325,12 +325,10 @@ class VerifyingMailSendView(APIView):
         user = request.user
         data = request.data
         email = data['email']
-        current_site = get_current_site(request)
-        domain = current_site.domain
         uidb64 = urlsafe_base64_encode(force_bytes(user.id))
         emailb64 = urlsafe_base64_encode(force_bytes(email))
         token = email_verification_token.make_token(user)
-        message_data = message(domain, uidb64, token, emailb64)
+        message_data = message(uidb64, token, emailb64)
 
         mail_title = "Team5_EveryTime 학교 인증 메일입니다."
         mail_to = email


### PR DESCRIPTION
각 서비스에서 redirect uri를 허용하는 것과 별개로,
social login view에서 redirect를 localhost로 보냈기 때문에 
배포 서버에서는 소셜로그인이 안되고 있었습니다.

해결을 위해
secrets.json에 BASE_URL을 넣었습니다.
로컬 secrets.json에는 다음을 추가해주시면 될것 같고,
 "BASE_URL": "http://127.0.0.1:8000/"
서버 secrets.json에는
"BASE_URL": "https://waffle-minkyu.shop" 을 넣어두었습니다. 