### PR TITLE
post like, scrap 구현

### DIFF
--- a/everytime/user/urls.py
+++ b/everytime/user/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path('verify/send/', views.VerifyingMailSendView.as_view(), name='email_verify_send'),
     path('verify/accepted/<str:uidb64>/<str:token>/<str:emailb64>/', views.VerifyingMailAcceptView.as_view(),
          name='email_verify_accept'),
+    path('myscrap/', views.UserScrapView.as_view(), name='myscrap')
 ]

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -405,11 +405,11 @@ class UserScrapView(APIView):
 
         current_url = request.scheme + '://' + request.get_host() + request.path
         if offset + limit < count:
-            next = current_url + f'?limit={limit}&offset={offset + 10}'
+            next = current_url + f'?limit={limit}&offset={offset + limit}'
         else:
             next = None
-        if offset > 10:
-            previous = current_url + f'?limit={limit}&offset={offset - 10}'
+        if offset > limit:
+            previous = current_url + f'?limit={limit}&offset={offset - limit}'
         elif offset == 0:
             previous = None
         else:

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse, JsonResponse
 from django.core.validators import validate_email
 from django.core.mail import EmailMessage
+from django.core.paginator import Paginator
 from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.encoding import force_bytes, force_text
 from django.conf import settings
@@ -30,6 +31,8 @@ from json.decoder import JSONDecodeError
 from .models import User, SocialAccount
 from .serializers import UserCreateSerializer, UserLoginSerializer, SocialUserCreateSerializer
 from .utils import email_verification_token, message
+
+from post.serializers import PostSerializer
 
 
 JWT_PAYLOAD_HANDLER = api_settings.JWT_PAYLOAD_HANDLER
@@ -387,3 +390,36 @@ class VerifyingMailAcceptView(APIView):
             return JsonResponse({"message": "TYPE_ERROR"}, status=400)
         except KeyError:
             return JsonResponse({"message": "INVALID_KEY"}, status=400)
+
+class UserScrapView(APIView):
+    permission_classes = (permissions.IsAuthenticated, )
+
+    def get(self, request):
+        user = request.user
+        query_params = request.query_params
+        limit = int(query_params.get('limit', 10))
+        offset = int(query_params.get('offset', 0))
+
+        scrap_posts = user.scrap_post.all()
+        count = len(scrap_posts)
+
+        current_url = request.scheme + '://' + request.get_host() + request.path
+        if offset + limit < count:
+            next = current_url + f'?limit={limit}&offset={offset + 10}'
+        else:
+            next = None
+        if offset > 10:
+            previous = current_url + f'?limit={limit}&offset={offset - 10}'
+        elif offset == 0:
+            previous = None
+        else:
+            previous = current_url + f'?limit={limit}'
+
+        results = PostSerializer(scrap_posts[offset:offset+limit], many=True).data
+
+        return JsonResponse({
+            'count': count,
+            'next': next,
+            'previous': previous,
+            'results': results
+        })


### PR DESCRIPTION
post like, scrap 구현
API
좋아요 누르기: `post/pk/like/`
스크랩 누르기: `post/pk/scrap/`
내가 스크랩한 글: `user/myscrap/`

내가 스크랩한 글 불러올 때 viewset 사용하지 않고 pagination을 구현하려고 했는데 paginator 사용하는 게 생각보다 원하는 커스터마이징이 쉽지 않고 직접 페이지네이션 구현해보는 것도 의미가 있겠다 싶어서 한번 코드로 짧게 만들어봤음
user.views 맨 밑에 구현해놨으니까 궁금하면 한 번 보고 리뷰 좀 부탁해!