### PR TITLE
Feat/refresh token

### DIFF
--- a/everytime/everytime/settings/base.py
+++ b/everytime/everytime/settings/base.py
@@ -58,7 +58,8 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'rest_framework',
-    'rest_framework_jwt',
+    # 'rest_framework_jwt',
+    'rest_framework_simplejwt',
     'rest_framework.authtoken',
     'drf_yasg',
     'storages',
@@ -172,19 +173,39 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework.authentication.TokenAuthentication',
-        'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        # 'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
     ),
 
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 10,
 }
 
-JWT_AUTH = {
-    'JWT_SECRET_KEY': SECRET_KEY,
-    'JWT_ALGORITHM': 'HS256',  # 암호화 알고리즘
-    'JWT_ALLOW_REFRESH': True,
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=2),  # 유효기간 설정
-    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=3),  # JWT 토큰 갱신 유효기간
+# 더 이상 안 쓰는 API임 (simple JWT로 변경함)
+# JWT_AUTH = {
+#     'JWT_SECRET_KEY': SECRET_KEY,
+#     'JWT_ALGORITHM': 'HS256',  # 암호화 알고리즘
+#     'JWT_ALLOW_REFRESH': True,
+#     'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=2),  # 유효기간 설정
+#     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=3),  # JWT 토큰 갱신 유효기간
+# }
+
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': datetime.timedelta(minutes=10),
+    'REFRESH_TOKEN_LIFETIME': datetime.timedelta(days=1),
+
+    'ALGORITHM': 'HS256',
+    'SIGNING_KEY': SECRET_KEY,
+
+    'USER_ID_FIELD': 'id',
+    'USER_ID_CLAIM': 'user_id',
+    'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
+
+    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'TOKEN_TYPE_CLAIM': 'token_type',
+
+    'JTI_CLAIM': 'jti',
+    'TOKEN_USER_CLASS': 'rest_framework_simplejwt.models.TokenUser',
 }
 
 AUTH_USER_MODEL = 'user.User'

--- a/everytime/everytime/urls.py
+++ b/everytime/everytime/urls.py
@@ -22,7 +22,7 @@ from django.conf.urls.static import static
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
-
+from rest_framework_simplejwt.views import TokenRefreshView
 from .views import ping
 
 
@@ -32,7 +32,8 @@ urlpatterns = [
     path('user/', include('user.urls')),
     path('board/', include('board.urls')),
     path('post/', include('post.urls')),
-    path('comment/', include('comment.urls'))
+    path('comment/', include('comment.urls')),
+    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]
 
 if settings.DEBUG_TOOLBAR:

--- a/everytime/everytime/urls.py
+++ b/everytime/everytime/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
     path('board/', include('board.urls')),
     path('post/', include('post.urls')),
     path('comment/', include('comment.urls')),
-    path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]
 
 if settings.DEBUG_TOOLBAR:

--- a/everytime/user/serializers.py
+++ b/everytime/user/serializers.py
@@ -3,18 +3,27 @@ from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import update_last_login
 from django.core.validators import RegexValidator
 from rest_framework import serializers
-from rest_framework_jwt.settings import api_settings
+# 더 이상 안 쓰는 API임 (simple JWT로 변경함)
+# from rest_framework_jwt.settings import api_settings
+from rest_framework_simplejwt.tokens import RefreshToken
 
 from user.models import SocialAccount
 
 User = get_user_model()
-JWT_PAYLOAD_HANDLER = api_settings.JWT_PAYLOAD_HANDLER
-JWT_ENCODE_HANDLER = api_settings.JWT_ENCODE_HANDLER
+# 더 이상 안 쓰는 API임 (simple JWT로 변경함)
+# JWT_PAYLOAD_HANDLER = api_settings.JWT_PAYLOAD_HANDLER
+# JWT_ENCODE_HANDLER = api_settings.JWT_ENCODE_HANDLER
 
 
 def jwt_token_of(user):
-    payload = JWT_PAYLOAD_HANDLER(user)
-    jwt_token = JWT_ENCODE_HANDLER(payload)
+    # 더 이상 안 쓰는 API임 (simple JWT로 변경함)
+    # payload = JWT_PAYLOAD_HANDLER(user)
+    # jwt_token = JWT_ENCODE_HANDLER(payload)
+    refresh = RefreshToken.for_user(user)
+    jwt_token = {
+        'refresh': str(refresh),
+        'access': str(refresh.access_token)
+    }
     return jwt_token
 
 

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -22,27 +22,17 @@ from rest_framework import status, viewsets, permissions
 from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 from rest_framework.response import Response
-from rest_framework_jwt.settings import api_settings
+# from rest_framework_jwt.settings import api_settings
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
 from json.decoder import JSONDecodeError
 from .models import User, SocialAccount
-from .serializers import UserCreateSerializer, UserLoginSerializer, SocialUserCreateSerializer
+from .serializers import UserCreateSerializer, UserLoginSerializer, SocialUserCreateSerializer, jwt_token_of
 from .utils import email_verification_token, message
 
 from post.serializers import PostSerializer
-
-
-JWT_PAYLOAD_HANDLER = api_settings.JWT_PAYLOAD_HANDLER
-JWT_ENCODE_HANDLER = api_settings.JWT_ENCODE_HANDLER
-
-
-def jwt_token_of(user):
-    payload = JWT_PAYLOAD_HANDLER(user)
-    jwt_token = JWT_ENCODE_HANDLER(payload)
-    return jwt_token
 
 
 class UserSignUpView(APIView):


### PR DESCRIPTION
요전 회의에서 말했다시피 restframework_jwt 는 사장된 라이브러리이기 때문에 restframework_simplejwt로 변경함
simplejwt에 대한 자세한 내용은 [공식문서](https://django-rest-framework-simplejwt.readthedocs.io/en/latest/)에서 확인할 수 있음! 설명이 꽤나 자세하게 나와있어서 나도 이거보고 많이 도움됐어

# `user/login/` response body 변경
refresh 토큰이 도입됨에 따라 user/login/ API의 response body가 다음과 같이 변경됨
![image](https://user-images.githubusercontent.com/71511067/148493162-4e20406d-fb61-446f-b0d2-ca340361b6d5.png)

# simple jwt를 이용해서 토큰 생성하는 코드
기존 jwt 라이브러리에서는 user를 payload_handler에 넣어서 payload 딕셔너리를 받아내고, 그 값을 encode_handler에 넣어서 token으로 변환하는 형식이었는데, simplejwt에서는 
``` python
from rest_framework_simplejwt.tokens import RefreshToken
...
def jwt_token_of(user):
    refresh = RefreshToken.for_user(user)
    jwt_token = {
        'refresh': str(refresh),
        'access': str(refresh.access_token)
    }
    return jwt_token
```
이런 식으로, RefreshToken 이라는 클래스에 정의된 for_user 함수를 이용해서 refresh 객체를 받아오고, 여기에 refresh와 access token이 둘다 저장되어있는데, refresh 토큰은 refresh 객체를 문자열화 함으로써, access 토큰은 refresh.access_token 을 문자열화함으로써 실제 토큰값으로 encoding 할 수 있음

# simple jwt에서 토큰을 받아오기 위한 API 헤더 변경
그리고 헤더에 Authorization 을 붙일 때, 기존에는 'JWT 토큰값' 이런 식이었는데, 이제는 'Bearer 토큰값' 이렇게 변경됨
``` json
{
    "Bearer": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjQxNTMwNDkwLCJpYXQiOjE2NDE1Mjk4OTAsImp0aSI6ImMzMTZhMDIwMGIwMjQzZGY4Y2QwNTVkZDJhNWUxY2M1IiwidXNlcl9pZCI6MX0.56YsUG06aD0RSEc2Xzmed8oIjb4Q2o_QoooqmeJtzFo",
}
```
물론 여기에 들어가는 토큰은 **access 토큰** 이어야 됨!!

# 토큰 refresh 하는 방법
그리고 토큰을 refresh하는 방법은, 다른 api들과 헷갈리지 않게 `token/refresh/` 로 따로 만들어놨는데, 여기서는 헤더가 아니라 request body로
``` json
{
    "refresh": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTY0MTYxNjI5MCwiaWF0IjoxNjQxNTI5ODkwLCJqdGkiOiJjMGFiYjQ0YzFhMjM0NDdmYWJkNjU5YjNhNzRhYTAxMSIsInVzZXJfaWQiOjF9.uBnfucOHcEvAcOn8qwhv7gbgrgG7fMj9q9lgu0YfZN0",
}
```
이런 식으로 실어보내면 
![image](https://user-images.githubusercontent.com/71511067/148494341-9732a2a9-94c2-49b5-aa4d-5ee69e1b33a0.png)

이런 식식으로 만료일이 갱신된 새로운 access 토큰이 발급됨

# settings/base.py 변경 내역
이건 각 라이브러리의 settings 파일을 보면 쉽게 알 수 있을 건데, 기존 jwt 라이브러리에서 토큰에 대한 설정을 변경해줄면 설정파일에서 다음과 같이 JWT_AUTH라는 딕셔너리를 정의하고 원하는 값을 넣어야 했음
``` python
JWT_AUTH = {
    'JWT_SECRET_KEY': SECRET_KEY,
    'JWT_ALGORITHM': 'HS256',  # 암호화 알고리즘
    'JWT_ALLOW_REFRESH': True,
    'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=2),  # 유효기간 설정
    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=3),  # JWT 토큰 갱신 유효기간
}
```
근데 새로운 라이브러리에서는 이것도 이름들이 조금씩 바뀌어서
```python
SIMPLE_JWT = {
    'ACCESS_TOKEN_LIFETIME': datetime.timedelta(minutes=10),
    'REFRESH_TOKEN_LIFETIME': datetime.timedelta(days=1),

    'ALGORITHM': 'HS256',
    'SIGNING_KEY': SECRET_KEY,

    'USER_ID_FIELD': 'id',
    'USER_ID_CLAIM': 'user_id',
    'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',

    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
    'TOKEN_TYPE_CLAIM': 'token_type',

    'JTI_CLAIM': 'jti',
    'TOKEN_USER_CLASS': 'rest_framework_simplejwt.models.TokenUser',
}
```
이런 식으로 바뀜
근데 사실 나도 여기서 머가 먼지 다 알지는 못하고 굳이 안 써도 되는데 혹시 몰라서 굳이굳이 써놓은 것들도 있어서 각 옵션들에 대한 설명은 맨 위에 언급한 공식문서에 들어가면 자세하게 적혀있으니 궁금하면 참고할 것!