### PR TITLE
Feat/top live

### DIFF
--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -13,11 +13,12 @@ class PostImageSerializer(serializers.ModelSerializer):
 
 
 class PostSerializer(serializers.ModelSerializer):
-    id = serializers.IntegerField(read_only=True)
-    board = serializers.StringRelatedField(read_only=True)
-    writer = serializers.SerializerMethodField(read_only=True)
+    id = serializers.IntegerField()
+    board = serializers.StringRelatedField()
+    writer = serializers.SerializerMethodField()
     title = serializers.CharField(required=False, max_length=100)
     content = serializers.CharField()
+    num_of_comments = serializers.SerializerMethodField()
     tags = serializers.PrimaryKeyRelatedField(queryset=Tag.objects.all(), many=True)
     images = serializers.SerializerMethodField()
     is_anonymous = serializers.BooleanField(default=False)
@@ -31,11 +32,15 @@ class PostSerializer(serializers.ModelSerializer):
             'writer',
             'title',
             'content',
+            'num_of_likes',
+            'num_of_scrap',
+            'num_of_comments',
             'tags',
             'images',
             'is_anonymous',
             'is_question',
         )
+        read_only_fields = ['id', 'board', 'writer', 'num_of_likes', 'num_of_scrap', 'num_of_comments']
 
     def get_writer(self, post):
         if post.is_anonymous:
@@ -45,6 +50,9 @@ class PostSerializer(serializers.ModelSerializer):
     def get_images(self, obj):
         image = obj.postimage_set.all()
         return PostImageSerializer(instance=image, many=True).data
+
+    def get_num_of_comments(self, obj):
+        return obj.comment_set.count()
 
     def validate(self, data):
         print(data)

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.shortcuts import render, get_object_or_404
 # from django.core.paginator import Paginator
 from django.http import JsonResponse
@@ -18,7 +16,9 @@ from .serializers import PostSerializer
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
+import datetime
 import re
+from pytz import utc
 
 from everytime.utils import ViewSetActionPermissionMixin
 
@@ -273,3 +273,14 @@ class PostViewSet(ViewSetActionPermissionMixin, viewsets.GenericViewSet):
                 })
             except:
                 raise exceptions.NotFound('게시글을 찾을 수 없습니다.')
+
+
+    @action(
+        detail=False,
+        methods=['GET'],
+    )
+    def livetop(self, request):
+        now = datetime.datetime.utcnow().replace(tzinfo=utc)
+        yesterday = now - datetime.timedelta(days=1)
+        queryset = Post.objects.filter(created_at__gt=yesterday).order_by('-num_of_likes')[:2]
+        return Response(PostSerializer(queryset, many=True).data, status=status.HTTP_200_OK)

--- a/everytime/requirements.txt
+++ b/everytime/requirements.txt
@@ -5,7 +5,7 @@ pytz==2021.1
 sqlparse==0.4.1
 django-debug-toolbar==2.2
 djangorestframework==3.11.1
-djangorestframework-jwt
+djangorestframework-simplejwt
 django-rest-authtoken
 Pillow  # profile picture 관련, 이미지처리
 drf-yasg


### PR DESCRIPTION
1. 포스트 serializer에서 좋아요, 스크랩, 댓글 수 안넘기는 걸 그동안 깜빡했네;;; 해당 부분 수정했고
2. 실시간 인기글 구현함! (에타에서 아래 부분) 구현 방법은 24시간 이내 게시글 중에서 좋아요 상위 2개 게시물 넘기는 방식임 API는 `post/toplive/`
![image](https://user-images.githubusercontent.com/71511067/148550769-31af89d5-052f-428a-96a1-5739cd17ad17.png)
