### PR TITLE
Fix : livetop / Feat : hot, main

### DIFF
--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -176,3 +176,25 @@ class HotSerializer(serializers.ModelSerializer):
     def get_title_or_content(self, post):
         return post.title + ' ' + post.content
 
+class TitleListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Post
+        fields = (
+            'title',
+            'created_at'
+        )
+
+class ContentListSerializer(serializers.ModelSerializer):
+    num_of_comments = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = (
+            'content',
+            'created_at',
+            'num_of_likes',
+            'num_of_comments'
+        )
+
+    def get_num_of_comments(self, obj):
+        return obj.comment_set.count()

--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -169,6 +169,7 @@ class HotSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = (
+            'id',
             'title_content',
             'created_at'
         )
@@ -180,6 +181,7 @@ class TitleListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = (
+            'id',
             'title',
             'created_at'
         )
@@ -190,6 +192,7 @@ class ContentListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Post
         fields = (
+            'id',
             'content',
             'created_at',
             'num_of_likes',

--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -140,3 +140,26 @@ class PostSerializer(serializers.ModelSerializer):
         post.save()
 
         return post
+
+
+class LiveTopSerializer(serializers.ModelSerializer):
+    board = serializers.SerializerMethodField()
+    num_of_comments = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = (
+            'id',
+            'board',
+            'title',
+            'content',
+            'num_of_comments'
+        )
+
+    def get_board(self, obj):
+        return obj.board.title
+
+    def get_num_of_comments(self, obj):
+        return obj.comment_set.count()
+
+

--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -163,3 +163,16 @@ class LiveTopSerializer(serializers.ModelSerializer):
         return obj.comment_set.count()
 
 
+class HotSerializer(serializers.ModelSerializer):
+    title_or_content = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Post
+        fields = (
+            'title_or_content',
+            'created_at'
+        )
+
+    def get_title_or_content(self, post):
+        return post.title + ' ' + post.content
+

--- a/everytime/post/serializers.py
+++ b/everytime/post/serializers.py
@@ -164,16 +164,16 @@ class LiveTopSerializer(serializers.ModelSerializer):
 
 
 class HotSerializer(serializers.ModelSerializer):
-    title_or_content = serializers.SerializerMethodField()
+    title_content = serializers.SerializerMethodField()
 
     class Meta:
         model = Post
         fields = (
-            'title_or_content',
+            'title_content',
             'created_at'
         )
 
-    def get_title_or_content(self, post):
+    def get_title_content(self, post):
         return post.title + ' ' + post.content
 
 class TitleListSerializer(serializers.ModelSerializer):

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -313,3 +313,12 @@ class PostViewSet(ViewSetActionPermissionMixin, viewsets.GenericViewSet):
         queryset = Post.objects.filter(created_at__gt=yesterday).order_by('-num_of_likes')[:2]
         return Response(LiveTopSerializer(queryset, many=True).data, status=status.HTTP_200_OK)
 
+    @action(
+        detail=False,
+        methods=['GET'],
+    )
+    def hot(self, request):
+        hot_posts = HotBoard.objects.all().values('post')
+        queryset = Post.objects.filter(id__in=hot_posts).order_by('-hotboard__created_at')[:4]
+        return Response(HotSerializer(queryset, many=True).data, status=status.HTTP_200_OK)
+

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -11,7 +11,7 @@ from comment.models import Comment
 from comment.serializers import CommentSerializer
 from .models import Post, Tag
 from board.models import Board, HotBoard, BestBoard
-from .serializers import PostSerializer
+from .serializers import PostSerializer, LiveTopSerializer, HotSerializer, TitleListSerializer, ContentListSerializer
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
@@ -41,10 +41,9 @@ def delete_tag(tags):
 class PostViewSet(ViewSetActionPermissionMixin, viewsets.GenericViewSet):
     permission_classes = (permissions.IsAuthenticated, )
     permission_action_classes = {
-        # 'retrieve': (permissions.AllowAny, ),
-        # 'list': (permissions.AllowAny, ),
-        # 'comment': (permissions.AllowAny, ),
-        # 'search': (permissions.AllowAny, )
+        'livetop': (permissions.AllowAny, ),
+        'hot': (permissions.AllowAny, ),
+        'main': (permissions.AllowAny, ),
         # 추후 메인화면에서 쓰일 simple list API 들에게 AllowAny 할당 예정
     }
     serializer_class = PostSerializer
@@ -309,8 +308,8 @@ class PostViewSet(ViewSetActionPermissionMixin, viewsets.GenericViewSet):
         methods=['GET'],
     )
     def livetop(self, request):
-        now = datetime.datetime.now().astimezone(tz=pytz.timezone(zone='Asia/Seoul')) # settings 에 timezone이 서울로 설정되어있으면 상관없는데 어차피 이거 settings의 timezone이랑 같으면 return self 하니까 혹시 몰라서 넣어둠
+        now = datetime.datetime.now()
         yesterday = now - datetime.timedelta(days=1)
         queryset = Post.objects.filter(created_at__gt=yesterday).order_by('-num_of_likes')[:2]
-        return Response(PostSerializer(queryset, many=True).data, status=status.HTTP_200_OK)
+        return Response(LiveTopSerializer(queryset, many=True).data, status=status.HTTP_200_OK)
 

--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -322,3 +322,21 @@ class PostViewSet(ViewSetActionPermissionMixin, viewsets.GenericViewSet):
         queryset = Post.objects.filter(id__in=hot_posts).order_by('-hotboard__created_at')[:4]
         return Response(HotSerializer(queryset, many=True).data, status=status.HTTP_200_OK)
 
+    @action(
+        detail=False,
+        methods=['GET'],
+    )
+    def main(self, request):
+        data = {}
+        boards = Board.objects.all()[:6]
+        for i in range(6):
+            board = boards[i]
+            if board.sub_boards.exists():
+                queryset = Post.objects.filter(board__head_board=board)
+            else:
+                queryset = Post.objects.filter(board=board)
+            if board.title_enabled:
+                data[board.title] = TitleListSerializer(queryset, many=True).data[:4]
+            else:
+                data[board.title] = ContentListSerializer(queryset, many=True).data[:2]
+        return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
1. PostSerializer 수정한 이후로 livetop API에서 오류가 발견돼서 수정함
2. livetop API에서 굳이 모든 포스트들의 정보를 가져올 필요는 없는 것 같아서 필요한 정보만 내보내도록 수정했고, 로그인 안 해도 리스트까지는 볼 수 있도록 권한 수정
3. `post/hot/` , `post/main/` API 신설 (hot은 핫게 최근 4개 리스트, main은 1~6번 게시판 최근 4개 or 2개(제목 없는 애들) 리스트)
4. livetop API 수정하는 김에 메인화면에서 사용하는 list API들은 불필요한 정보 없애고 로그인 안 해도 사용할 수 있도록 수정함

