### PR TITLE
Refact : friend

### DIFF
--- a/everytime/everytime/urls.py
+++ b/everytime/everytime/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path('comment/', include('comment.urls')),
     path('lecture/', include('lecture.urls')),
     path('timetable/', include('timetable.urls')),
+    path('friend/', include('friend.urls')),
     path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]
 

--- a/everytime/friend/urls.py
+++ b/everytime/friend/urls.py
@@ -5,5 +5,6 @@ from . import views
 urlpatterns = [
     path('', views.FriendListView.as_view(), name='Friend list'),
     path('<int:pk>/', views.FriendView.as_view(), name='Accept friend'),
-    path('request/', views.FriendRequestView.as_view(), name='Request friend')
+    path('request/', views.FriendRequestView.as_view(), name='Request friend'),
+    path('request/<int:pk>/', views.FriendRequestDeleteView.as_view(), name='Delete Request')
 ]

--- a/everytime/friend/urls.py
+++ b/everytime/friend/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+from . import views
+
+
+urlpatterns = [
+    path('', views.FriendListView.as_view(), name='Friend list'),
+    path('<int:pk>/', views.FriendView.as_view(), name='Accept friend'),
+    path('request/', views.FriendRequestView.as_view(), name='Request friend')
+]

--- a/everytime/friend/views.py
+++ b/everytime/friend/views.py
@@ -1,39 +1,80 @@
-from rest_framework import viewsets, views, permissions, status
+from django.db.transaction import atomic
+from rest_framework import viewsets, permissions, status, generics
+from rest_framework.decorators import action
 from rest_framework.response import Response
-from .models import Friend
+from user.models import User
+from .models import Friend, FriendRequest
 from .serializers import FriendRequestSerializer, FriendSerializer
+from everytime.exceptions import FieldError, ServerError, NotFound
 
 # Create your views here.
-class FreindRequestView(views.APIView):
+class FriendRequestView(generics.GenericAPIView):
     permission_classes = (permissions.IsAuthenticated, )
+    serializer_class = FriendRequestSerializer
 
     def post(self, request):
         data = request.data
-        user = request.user
-        data['sender'] = user.nickname or None
-        serializer = FriendRequestSerializer(data=data)
-        serializer.is_valid(raise_exception=True)
-        friend_request = serializer.save()
-        return Response(FriendRequestSerializer(friend_request).data, status=status.HTTP_201_CREATED) # 이 부분 직접 친구신청 해보고 response 수정해야됨
-
-class FriendViewset(viewsets.GenericViewSet):
-    permission_classes = (permissions.IsAuthenticated, )
-    serializer_class = FriendSerializer
-
-    def create(self, request):
-        data = request.data
-        user = request.user
-        data['user'] = user.nickname or None
         serializer = self.get_serializer(data=data)
         serializer.is_valid(raise_exception=True)
         friend_request = serializer.save()
-        queryset = Friend.objects.filter(user=user)
-        return Response(self.get_serializer(queryset, many=True).data, status=status.HTTP_201_CREATED)
-
-    def list(self, request):
-        user = request.user
-        queryset = Friend.objects.filter(user=user)
-        return Response(self.get_serializer(queryset, many=True).data, status=status.HTTP_200_OK)
+        if friend_request is None:
+            raise ServerError()
+        return Response("친구 요청을 보냈습니다.\n상대방이 수락하면 친구가 맺어짖니다.", status=status.HTTP_201_CREATED) # 이 부분 직접 친구신청 해보고 response 수정해야됨
 
     def delete(self, request):
-        pass
+        data = request.data
+        user = request.user
+        sender = data.get('sender', None)
+        if sender is None:
+            raise FieldError()
+        try:
+            delete_request = FriendRequest.objects.get(sender=sender, receiver=user)
+        except:
+            raise ServerError()
+        delete_request.delete()
+        return Response("친구 요청을 거절하였습니다.", status=status.HTTP_200_OK)
+
+
+
+class FriendView(generics.GenericAPIView):
+    permission_classes = (permissions.IsAuthenticated, )
+    serializer_class = FriendSerializer
+
+    def post(self, request, pk=None):
+        user = request.user
+        if not pk:
+            raise FieldError('친구 신청을 확인해주세요.')
+        serializer = self.get_serializer(data={'friend': pk})
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response("친구 요청을 수락하였습니다.", status=status.HTTP_201_CREATED)
+
+    def delete(self, request, pk=None):
+        user = request.user
+        if not pk:
+            raise FieldError('삭제할 친구를 입력해주세요.')
+        try:
+            friend = User.objects.get(pk=pk)
+            relation1 = Friend.objects.get(user=user, friend=friend)
+            relation2 = Friend.objects.get(user=friend, friend=user)
+        except:
+            raise NotFound('존재하지 않는 친구입니다.')
+        with atomic():
+            relation1.delete()
+            relation2.delete()
+        return Response("친구를 삭제하였습니다.", status=status.HTTP_200_OK)
+
+class FriendListView(generics.GenericAPIView):
+    permission_classes = (permissions.IsAuthenticated, )
+    serializer_class = FriendSerializer
+
+    def get(self, request):
+        user = request.user
+        queryset = Friend.objects.filter(user=user)
+        request_queryset = FriendRequest.objects.filter(receiver=user)
+        request_exist = request_queryset.exists()
+        return Response({
+            "request_exist": request_exist,
+            "request_list": request_queryset.values('sender__id', 'sender__nickname'),
+            "friend_list": queryset.values('friend__id', 'friend__nickname')
+        }, status=status.HTTP_200_OK)

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -57,7 +57,7 @@ class UserSignUpView(APIView):
         Point.objects.create(user=user, reason='기본 포인트 지급', point=20)
         semesters = Semester.objects.all()
         for semester in semesters:
-            TimeTable.objects.creeate(semester=semester, user=user, is_default=True, name='시간표 1')
+            TimeTable.objects.create(semester=semester, user=user, is_default=True, name='시간표 1')
         return Response({
             'user': user.username,
             'token': jwt_token


### PR DESCRIPTION
# 변경사항
1. 가입할 때 `TimeTable.objects.create` 에서 오타가 있어서 오류나는 문제 수정
2. 친구 API들 URL로 구현
3. 친구 수락 viewset -> view로 수정하고 API 몇 개 추가

* * *

# 상세 내역
친구 API는 크게 4개로 나뉨 [친구 요청, 요청/친구 리스트, 친구 수락, 친구 삭제]

## 1. 친구 요청
### URL
POST `friend/request/`
### request
receiver : string (상대 아이디)
### response
"친구 요청을 보냈습니다.\n상대방이 수락하면 친구가 맺어짖니다."

## 2. 친구 요청 삭제
### URL
DELETE `friend/request/pk/
### response
"친구 요청을 거절하였습니다."

## 3. 친구 수락
### URL
POST `friend/pk/`
### response
"친구 요청을 수락하였습니다."

## 4. 친구 삭제
### URL
DELETE `friend/pk/`
### response
"친구를 삭제하였습니다."

## 5. 요청/친구 리스트
### URL
GET `friend/`
### response
request_exist : bool (요청이 존재하는지)
request_list : List (화면에 보여지는 건 nickname 부분이고 id는 친구 요청을 수락할 때 사용)
friend_list : 위와 같음(id는 친구를 삭제할 때 사용)
![image](https://user-images.githubusercontent.com/71511067/150193805-4c1f8cb7-8713-4060-b1cb-e8ee6d12cb3e.png)