### PR TITLE
게시글 생성 시 tags 입력 안 되는 오류 수정

### DIFF
--- a/everytime/post/views.py
+++ b/everytime/post/views.py
@@ -1,5 +1,6 @@
 import pytz
 from django.http import JsonResponse
+from django.http.request import QueryDict
 from django.utils import timezone
 
 from rest_framework import status, viewsets, permissions
@@ -26,11 +27,14 @@ from everytime.utils import ViewSetActionPermissionMixin, get_object_or_404
 def create_tag(data):
     if 'tags' in data:
         all_tag = Tag.objects.all()
-        if hasattr(data, 'getlist'):
-            for tag_name in data.getlist('tags'):
-                tag_name = tag_name.upper()
-                if not all_tag.filter(name__iexact=tag_name).exists():
-                    Tag.objects.create(name=tag_name)
+        if isinstance(data, QueryDict):
+            tags = data.getlist('tags', [])
+        else:
+            tags = data.get('tags', [])
+        for tag_name in tags:
+            tag_name = tag_name.upper()
+            if not all_tag.filter(name__iexact=tag_name).exists():
+                Tag.objects.create(name=tag_name)
 
 def delete_tag(tags):
     for tag in tags:
@@ -50,7 +54,7 @@ class PostViewSet(ViewSetActionPermissionMixin, viewsets.GenericViewSet):
     queryset = Post.objects.all()
 
     def create(self, request):
-        data = request.data.copy()
+        data = request.data
 
         create_tag(data)
 


### PR DESCRIPTION
와 이런 코너케이스는 상상도 못했는데...
일단 오류 원인을 설명하자면 포스트맨에서 API reqeust를 보낼 때 body 데이터를 form-data로 할 수도 있고 raw(json)으로 입력할 수도 있잖아?
전자의 경우
tags : tag1
tags : tag2
이렇게 해야 여러 개의 태그를 전송할 수 있고
후자의 경우는
"tags": ["tag1", "tag2"]
이렇게 전송해야 되거든
근데 전자의 경우는 request.data의 자료형이 djagno.http.request.QueryDict이고 후자의 경우는 그냥 기본 dict더라고.. 이유는 모르겠음
근데 QueryDict의 경우 리스트 자료형을 뽑아내는 방법이 `.getlist`이고, 이렇게 안 하면 무조건 마지막 값이 반환돼. 그리고 dict는 그냥 `.get`을 해도 리스트를 얻을 수 있어.
난 귀찮아서 json형태의 body로는 테스트를 안 하고 form-data로만 테스트했는데 프론트 분들은 거의 json형태로 데이터를 보내서 오류가 나는 거더라...
아무튼 이런 부분 미리 테스트 못 해서 미안 ㅠㅠ 너네들도 request 바디에서 list로 받아오는 아이템 있으면 참고해!!