### PR TITLE
Feat/logout

### DIFF
--- a/everytime/everytime/settings/base.py
+++ b/everytime/everytime/settings/base.py
@@ -62,6 +62,7 @@ INSTALLED_APPS = [
     'rest_framework',
     # 'rest_framework_jwt',
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
     'rest_framework.authtoken',
     'drf_yasg',
     'storages',
@@ -189,14 +190,6 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 10,
 }
 
-# 더 이상 안 쓰는 API임 (simple JWT로 변경함)
-# JWT_AUTH = {
-#     'JWT_SECRET_KEY': SECRET_KEY,
-#     'JWT_ALGORITHM': 'HS256',  # 암호화 알고리즘
-#     'JWT_ALLOW_REFRESH': True,
-#     'JWT_EXPIRATION_DELTA': datetime.timedelta(hours=2),  # 유효기간 설정
-#     'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=3),  # JWT 토큰 갱신 유효기간
-# }
 
 SIMPLE_JWT = {
     'ACCESS_TOKEN_LIFETIME': datetime.timedelta(minutes=60),
@@ -209,7 +202,7 @@ SIMPLE_JWT = {
     'USER_ID_CLAIM': 'user_id',
     'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
 
-    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
+    'AUTH_TOKEN_CLASSES': ('everytime.utils.AccessToken',),
     'TOKEN_TYPE_CLAIM': 'token_type',
 
     'JTI_CLAIM': 'jti',

--- a/everytime/everytime/utils.py
+++ b/everytime/everytime/utils.py
@@ -1,5 +1,11 @@
 from django.shortcuts import _get_queryset
 from .exceptions import NotFound
+from rest_framework_simplejwt.tokens import AccessToken, BlacklistMixin
+
+
+class AccessToken(BlacklistMixin, AccessToken):
+    pass
+
 
 class ViewSetActionPermissionMixin:
     def get_permissions(self):

--- a/everytime/user/urls.py
+++ b/everytime/user/urls.py
@@ -8,6 +8,7 @@ app_name='user'
 urlpatterns = [
     path('signup/', views.UserSignUpView.as_view(), name='signup'),
     path('login/', views.UserLoginView.as_view(), name='login'),
+    path('logout/', views.UserLogoutView.as_view(), name='logout'),
     path('kakao/login/', views.KaKaoLoginView.as_view(), name='kakao login'),
     path('kakao/login/callback/', views.kakao_callback, name='kakao callback'),
     path('google/login/', views.GoogleLoginView.as_view(), name='google_login'),

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -23,9 +23,10 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 from rest_framework.response import Response
-# from rest_framework_jwt.settings import api_settings
+from rest_framework_simplejwt.tokens import RefreshToken
 
 from everytime.exceptions import AlreadyLogin, SocialLoginError, DatabaseError, FieldError, DuplicationError
+from everytime.utils import AccessToken
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -74,6 +75,16 @@ class UserLoginView(APIView):
         token = serializer.validated_data['token']
 
         return Response({'success': True, 'token': token}, status=status.HTTP_200_OK)
+
+class UserLogoutView(APIView):
+    permission_classes(permissions.IsAuthenticated, )
+
+    def post(self, request):
+        refresh_token = RefreshToken(request.data.get('refresh'))
+        access_token = AccessToken(request.META.get('HTTP_AUTHORIZATION').split()[1])
+        refresh_token.blacklist()
+        access_token.blacklist()
+        return Response("Success")
 
 
 class UserProfileView(APIView):


### PR DESCRIPTION
# 구현 내용
1. 로그아웃 구현
2. 로그아웃에 필요한 토큰블랙리스트 모델 마이그레이션 하였음

# 구현 방법
1. installed_app에 `'rest_framework_simplejwt.token_blacklist'` 을 추가한다.
2. refresh 토큰을 body로 받아서 `rest_framework_simplejwt.tokens.RefreshToken()`에 대입한다.
3. 위 RefreshToken의 객체를 받아서 token.blacklist() 를 실행한다. -> 블랙리스트 데이터베이스에 토큰이 저장됨
AccessToken은 기본적으로 블랙리스트 기능이 없어서 blacklistmixin을 상속받은 AccessToken을 `everytime.utils` 에 재정의해서 위 방법과 같은 절차로 폐기처분했음!