### PR TITLE
Feat/mypost mycomment

### DIFF
--- a/everytime/user/urls.py
+++ b/everytime/user/urls.py
@@ -19,5 +19,7 @@ urlpatterns = [
     path('verify/accepted/<str:uidb64>/<str:token>/<str:emailb64>/', views.VerifyingMailAcceptView.as_view(),
          name='email_verify_accept'),
     path('myscrap/', views.UserScrapView.as_view(), name='myscrap'),
+    path('mypost/', views.UserPostView.as_view(), name='myscrap'),
+    path('mycomment/', views.UserCommentView.as_view(), name='myscrap'),
     path('myprofile/', views.UserProfileView.as_view(), name='myprofile'),
 ]

--- a/everytime/user/views.py
+++ b/everytime/user/views.py
@@ -418,3 +418,25 @@ class UserScrapView(GenericAPIView):
         return self.get_paginated_response(data)
 
 
+class UserPostView(GenericAPIView):
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = PostSerializer
+
+    def get(self, request):
+        user = request.user
+        queryset = user.post_set.order_by('-id')
+        page = self.paginate_queryset(queryset)
+        data = self.get_serializer(page, many=True).data
+        return self.get_paginated_response(data)
+
+
+class UserCommentView(GenericAPIView):
+    permission_classes = (permissions.IsAuthenticated,)
+    serializer_class = PostSerializer
+
+    def get(self, request):
+        user = request.user
+        queryset = Post.objects.filter(id__in=user.comment_set.values("post")).order_by('-id')
+        page = self.paginate_queryset(queryset)
+        data = self.get_serializer(page, many=True).data
+        return self.get_paginated_response(data)


### PR DESCRIPTION
# 구현 내용
1. 내가 스크랩한 글 API 를 장고 자체 pagination으로 교체
2. 내가 쓴 글, 내가 댓글 단 글 API 구현

# 구현 방법
views.APIView말고 generic.GenericAPIView 를 쓰자!!
원래 APIView에서 pagination이 적용이 안 돼서 직접 구현했던 건데 GenericAPIView를 사용하니까 장고에서 기본으로 제공하는 pagination을 적용할 수 있음
사실 View말고 ViewSet 쓰는 이유가 다양한 url의 API를 하나의 클래스에서 정의할 수 있다는 것 외에도 get_serializer, paginated_queryset 등 다양한 추가 메서드가 많아서 이기도한데 알고보니 APIView에서 기능을 확장한 GenericAPIView라는 게 있더라고
이걸 제외하면 API들을 views.py에서 구현하냐 urls.py에서 구현하냐 정도의 차이만 있어서 때로는 간단하게 정의할 수 있는 GenericAPIView를 쓸 일도 많을 것 같음