### PR TITLE
Fix/allowed host

### DIFF
--- a/everytime/everytime/settings/base.py
+++ b/everytime/everytime/settings/base.py
@@ -45,6 +45,7 @@ ALLOWED_HOSTS = [
     '13.125.247.56',
     '127.0.0.1',
     'localhost',
+    'waffle-minkyu.shop'
 ]
 
 # Application definition

--- a/everytime/everytime/settings/base.py
+++ b/everytime/everytime/settings/base.py
@@ -45,7 +45,8 @@ ALLOWED_HOSTS = [
     '13.125.247.56',
     '127.0.0.1',
     'localhost',
-    'waffle-minkyu.shop'
+    'waffle-minkyu.shop',
+    'www.waffle-minkyu.shop'
 ]
 
 # Application definition


### PR DESCRIPTION
## 개선사항
Pagination 시에 previous / next URL이 localhost~~ 로 나오는 문제 수정

## 변경 내역
1. Nginx 설정을 다음과 같이 변경 -> 이 부분은 서버에서 직접 바꾼 거라 커밋내용에 포함되지 않으므로 아래 요약 참고
![image](https://user-images.githubusercontent.com/71511067/151424249-fbe76c1e-e3df-48c5-ae8a-a0ca7dec3bb8.png)
proxy_pass ~~ 는 원래 있던 부분이고 그 위에 4줄 추가했음
간단히 설명하자면 https://waffle-minkyu.shop/~~~/ 로 API 요청이 들어오면 Nginx 에서 이걸 서버 컴퓨터의 장고 서버가 돌아가고 있는 주소인 http://localhost:8000/~~~/ 로 연결시켜주는 방식이었어
여기서 장고는 헤더를 보고 호스트를 판단하는데 별다른 설정이 없으면 Nginx는 요청한 URL이 아니라 내부 URL을 장고에게 넘겨줌
근데 새로 추가한 명령어들에 의해서 Nginx는 실제로는 http://localhost:8000/~~~/ 으로 API를 요청하지만 Header에 현재 URL이 https://waffle-minkyu.shop/~~~/ 임을 명시하게 해주는 거야
나도 속성으로 구글링해서 배운 거라 정확하지 않을 수 있으니 그냥 대강 그렇구나~ 정도로 한귀로 흘리고 더 자세히 알고싶으면 한 번 찾아보면 좋을 것 같아!
2. 그리고 위에서 바꾼 설정에 의해 장고는 localhost가 아니라 waffle-minkyu.shop에서 요청을 받은 것으로 인식하게 되므로 설정에서 ALLOWED_HOST에 waffle-minkyu.shop 이라는 주소를 추가해줬어